### PR TITLE
Add py3, systemd, and packaging support

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -23,15 +23,22 @@ install -s -p build/DAEMON/$DAEMON_NAME $PREFIX/sbin
 if test -n "${NO_SYSTEM_INSTALL}" ; then exit ; fi
 
 # Install the init script
-install -p -T initscript /etc/init.d/$DAEMON_NAME
+if test -d /etc/init.d ; then
+    sed "s:DAEMON_DIRECTORY:$PREFIX/sbin:" <initscript >/etc/init.d/$DAEMON_NAME
 
-# Set the daemon directory in the init script
-sed -i "s:DAEMON_DIRECTORY:$PREFIX/sbin:" /etc/init.d/$DAEMON_NAME
+    # Enable the service to start on boot
+    update-rc.d $DAEMON_NAME defaults
+    # Restart the service
+    service $DAEMON_NAME restart
+fi
 
-# Enable the service to start on boot
-update-rc.d $DAEMON_NAME defaults
-# Restart the service
-service $DAEMON_NAME restart
+# Install the systemd service
+if test -d /etc/systemd/system ; then
+    sed "s:DAEMON_DIRECTORY:$PREFIX/sbin:" <systemdscript >/etc/systemd/system/$DAEMON_NAME.service
+    systemd daemon-reload
+    systemd enable $DAEMON_NAME.service
+    systemd restart $DAEMON_NAME.service
+fi
 
 # Check whether I2C is enabled in the device tree
 if ! grep -q ^dtparam=i2c_arm=on /boot/config.txt

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -8,12 +8,20 @@ SO_NAME=liblifepo4wered.so
 # Install prefix
 PREFIX=${PREFIX-/usr/local}
 
+install -d $PREFIX/lib
+install -d $PREFIX/bin
+install -d $PREFIX/sbin
+
 # Install the shared object
 install -p build/SO/$SO_NAME $PREFIX/lib
 # Install the CLI
 install -s -p build/CLI/$CLI_NAME $PREFIX/bin
 # Install the daemon
 install -s -p build/DAEMON/$DAEMON_NAME $PREFIX/sbin
+
+# exit when building packages
+if test -n "${NO_SYSTEM_INSTALL}" ; then exit ; fi
+
 # Install the init script
 install -p -T initscript /etc/init.d/$DAEMON_NAME
 

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -19,9 +19,6 @@ install -s -p build/CLI/$CLI_NAME $PREFIX/bin
 # Install the daemon
 install -s -p build/DAEMON/$DAEMON_NAME $PREFIX/sbin
 
-# exit when building packages
-if test -n "${NO_SYSTEM_INSTALL}" ; then exit ; fi
-
 # Install the init script
 if test -d /etc/init.d ; then
     sed "s:DAEMON_DIRECTORY:$PREFIX/sbin:" <initscript >/etc/init.d/$DAEMON_NAME

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+
+all:
+	python3 build.py
+install:
+	env PREFIX=${DESTDIR}/usr NO_SYSTEM_INSTALL=nope bash INSTALL.sh
+clean:
+	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 
+PREFIX ?= /usr
+
 help:
 	-echo "Make goals:"
 	-echo "  all     - build programs"
@@ -14,7 +16,7 @@ all:
 	test -d debian && \
 	sed "s:DAEMON_DIRECTORY:${PREFIX}/sbin:" < systemdscript > debian/lifepo4wered.service
 inst:
-	env PREFIX=${DESTDIR}/usr bash INSTALL.sh
+	env PREFIX=${PREFIX} bash INSTALL.sh
 install:
 	env PREFIX=${DESTDIR}/usr NO_SYSTEM_INSTALL=nope bash INSTALL.sh
 clean:

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,13 @@ help:
 	-echo "  clean   - delete generated files"
 all:
 	python3 build.py
+
+	test -d debian && \
+	sed "s:DAEMON_DIRECTORY:${PREFIX}/sbin:" < initscript > debian/lifepo4wered.init
 inst:
 	env PREFIX=${DESTDIR}/usr bash INSTALL.sh
 install:
 	env PREFIX=${DESTDIR}/usr NO_SYSTEM_INSTALL=nope bash INSTALL.sh
 clean:
 	rm -rf build
+	-rm -f debian/lifepo4wered.init

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,12 @@ help:
 	-echo "Make goals:"
 	-echo "  all     - build programs"
 	-echo "  install - install programs to $$PREFIX"
+	-echo "  inst    - install programs and update system"
 	-echo "  clean   - delete generated files"
 all:
 	python3 build.py
+inst:
+	env PREFIX=${DESTDIR}/usr bash INSTALL.sh
 install:
 	env PREFIX=${DESTDIR}/usr NO_SYSTEM_INSTALL=nope bash INSTALL.sh
 clean:

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,8 @@ help:
 all:
 	python3 build.py
 
-	test -d debian && \
-	sed "s:DAEMON_DIRECTORY:${PREFIX}/sbin:" < initscript > debian/lifepo4wered.init
-
-	test -d debian && \
-	sed "s:DAEMON_DIRECTORY:${PREFIX}/sbin:" < systemdscript > debian/lifepo4wered.service
-inst:
-	env PREFIX=${PREFIX} bash INSTALL.sh
 install:
-	env PREFIX=${DESTDIR}/usr NO_SYSTEM_INSTALL=nope bash INSTALL.sh
+	env PREFIX=${PREFIX} NO_SYSTEM_INSTALL=nope bash INSTALL.sh
 clean:
 	rm -rf build
 	-rm -f debian/lifepo4wered.init

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ all:
 
 	test -d debian && \
 	sed "s:DAEMON_DIRECTORY:${PREFIX}/sbin:" < initscript > debian/lifepo4wered.init
+
+	test -d debian && \
+	sed "s:DAEMON_DIRECTORY:${PREFIX}/sbin:" < systemdscript > debian/lifepo4wered.service
 inst:
 	env PREFIX=${DESTDIR}/usr bash INSTALL.sh
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 
+help:
+	-echo "Make goals:"
+	-echo "  all     - build programs"
+	-echo "  install - install programs to $$PREFIX"
+	-echo "  clean   - delete generated files"
 all:
 	python3 build.py
 install:

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Access library, command line tool and daemon for the LiFePO4wered/Pi+ and legacy
 ## Installation
 
 Starting from a fresh Raspbian image, first install the `build-essential`,
-`git` and `python` packages:
+`git` and `python` packages, and the systemd support library:
 
 ```
-sudo apt-get -y install build-essential git python
+sudo apt-get -y install build-essential git python libsystemd-dev
 ```
 
 In a directory where you keep source code, clone the LiFePO4wered-Pi repository
@@ -36,6 +36,15 @@ sudo ./INSTALL.sh
 ```
 
 That's it!  You may need to restart for some configuration changes to take effect.
+
+## Daemon
+
+The installation script installs a background program
+("lifepo4wered-daemon"), along with scripts to start it. You can also start
+the daemon manually; it will continue run in the background.
+
+The daemon supports startup via systemd, including its notification
+and keepalive features. See "man systemd.service" for details.
 
 ## CLI
 

--- a/build.py
+++ b/build.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+
+from __future__ import print_function
+
 from fabricate import *
 import os
 
@@ -31,9 +34,17 @@ build_targets = {
     ],
     'cflags': '-std=c99 -Wall -O2 -fpic'.split(),
     'lflags': '-shared'.split()
-  }
+  },
+  'SYSTEMD': {
+    'name': 'systemd-check',
+    'sources': [
+      'systemd-check'
+    ],
+    'cflags': '-std=c99 -Wall -O2'.split(),
+    'lflags': '-lsystemd'.split()
+  },
 }
-    
+
 def build(target=None):
     compile(target=target)
     link(target=target)
@@ -45,10 +56,34 @@ def so():
     build('SO')
 
 def daemon():
+    check_systemd()
     build('DAEMON')
+
+def systemd():
+    compile(target="SYSTEMD")
+    link(target="SYSTEMD")
 
 def oname(build_dir, target, filename):
     return os.path.join(build_dir, target, os.path.basename(filename))
+
+SYSTEMD = None
+def check_systemd():
+    global SYSTEMD
+    if SYSTEMD is not None:
+        return SYSTEMD
+    try:
+        compile(target="SYSTEMD")
+        link(target="SYSTEMD")
+    except Exception as exc:
+        print("No systemd library found.")
+        SYSTEMD=False
+        return
+
+    print("Systemd library found.")
+    for val in build_targets.values():
+        val['cflags'].append('-DSYSTEMD')
+        val['lflags'].append('-lsystemd')
+    SYSTEMD=True
 
 def compile(build_dir='build', target=None, flags=None):
     if target != None:

--- a/build.py
+++ b/build.py
@@ -86,6 +86,8 @@ def check_systemd():
     SYSTEMD=True
 
 def compile(build_dir='build', target=None, flags=None):
+    if target != "SYSTEMD":
+      check_systemd()
     if target != None:
       targets = [target]
     else:

--- a/lifepo4wered-daemon.c
+++ b/lifepo4wered-daemon.c
@@ -17,6 +17,9 @@
 #include <time.h>
 #include "lifepo4wered-data.h"
 
+#ifdef SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
 
 /* Time difference (s) for the system time to be updated from the RTC */
 
@@ -109,6 +112,17 @@ void system_time_to_rtc(void) {
 int main(int argc, char *argv[]) {
   bool trigger_shutdown = false;
 
+#ifdef SYSTEMD
+  struct timespec wd_sleep;
+  uint64_t watchdog_usec;
+
+  if (sd_watchdog_enabled(0, &watchdog_usec) <= 0)
+    watchdog_usec = 0;
+  else
+    watchdog_usec = watchdog_usec*2/3; // signal more often
+
+  if (sd_notify(0, "STATUS=Startup") == 0)
+#endif
   /* Fork and detach to run as daemon */
   if (daemon(0, 0))
     return 1;
@@ -127,6 +141,10 @@ int main(int argc, char *argv[]) {
   /* If available and necessary, restore the system time from the RTC */
   system_time_from_rtc();
 
+#ifdef SYSTEMD
+  sd_notify(0, "READY=1");
+#endif
+
   /* Sleep while the Pi is on, until this daemon gets a signal
    * to terminate (which might be because the LiFePO4wered/Pi
    * running flag is reset) */
@@ -139,6 +157,12 @@ int main(int argc, char *argv[]) {
     }
     
     /* Sleep most of the time */
+
+#ifdef SYSTEMD
+    if (watchdog_usec > 0)
+        usleep(watchdog_usec);
+    else
+#endif
     sleep(1);
   }
 

--- a/lifepo4wered-daemon.c
+++ b/lifepo4wered-daemon.c
@@ -50,7 +50,7 @@ void set_term_handler(void) {
 
 /* Shut down the system */
 
-void shutdown(void) {
+void shut_down(void) {
   syslog(LOG_INFO, "Triggering system shutdown");
   char *params[3] = {"init", "0", NULL};
   execv("/sbin/init", params);
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
 
   /* If we need to trigger a shutdown, do it now */
   if (trigger_shutdown)
-    shutdown();
+    shut_down();
 
   /* Close the syslog */
   closelog();

--- a/lifepo4wered-daemon.c
+++ b/lifepo4wered-daemon.c
@@ -113,7 +113,6 @@ int main(int argc, char *argv[]) {
   bool trigger_shutdown = false;
 
 #ifdef SYSTEMD
-  struct timespec wd_sleep;
   uint64_t watchdog_usec;
 
   if (sd_watchdog_enabled(0, &watchdog_usec) <= 0)

--- a/systemd-check.c
+++ b/systemd-check.c
@@ -1,0 +1,6 @@
+#include <stdlib.h>
+#include <systemd/sd-daemon.h>
+int main() {
+	sd_notify(0, "STATUS=Test");
+	exit(0);
+}

--- a/systemdscript
+++ b/systemdscript
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daemon for lifepo4wered Pi hat
+
+[Service]
+Type=forking
+#NotifyAccess=main
+ExecStart=DAEMON_DIRECTORY/lifepo4wered-daemon
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=sysinit.target

--- a/systemdscript
+++ b/systemdscript
@@ -2,11 +2,12 @@
 Description=Daemon for lifepo4wered Pi hat
 
 [Service]
-Type=forking
+Type=notify
 #NotifyAccess=main
 ExecStart=DAEMON_DIRECTORY/lifepo4wered-daemon
 Restart=always
 RestartSec=10
+WatchdogSec=1
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
This bunch of patches adds
* py3 support to fabricate
* support for systemd ("notify" mode, i.e. startup halts until the RTC is read) and its watchdog feature
* support for INSTALL.sh to skip paths that are not below PREFIX
* a Makefile, so that packaging simply can call "make" and "make install PREFIX=…"