### PR TITLE
Revert "lifepo4wered-daemon: Ignore sd_notify return value"

### DIFF
--- a/lifepo4wered-daemon.c
+++ b/lifepo4wered-daemon.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
   bool trigger_shutdown = false;
 
 #ifdef SYSTEMD
-  sd_notify(0, "STATUS=Startup");
+  if (sd_notify(0, "STATUS=Startup") == 0)
 #endif
   /* Fork and detach to run as daemon */
   if (daemon(0, 0))


### PR DESCRIPTION
systemd needs the daemon to avoid forking for notification to work.

This reverts commit fb52ecc2e3342ff4982e39be3c96a0925c5587f0.