### PR TITLE
Fix systemd sd_notify conditional and add additional notifications

### DIFF
--- a/lifepo4wered-daemon.c
+++ b/lifepo4wered-daemon.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
   bool trigger_shutdown = false;
 
 #ifdef SYSTEMD
-  if (sd_notify(0, "STATUS=Startup") == 0) {
+  sd_notify(0, "STATUS=Startup");
 #endif
   /* Run in foreground if -f flag is passed */
   if (argc == 2 && strcmp(argv[1], "-f") == 0)
@@ -135,9 +135,6 @@ int main(int argc, char *argv[]) {
   /* Otherwise fork and detach to run as daemon */
   else if (daemon(0, 0))
     return 1;
-#ifdef SYSTEMD
-  }
-#endif
 
   /* Open the syslog if we need to */
   if (!foreground)

--- a/lifepo4wered-daemon.c
+++ b/lifepo4wered-daemon.c
@@ -176,6 +176,11 @@ int main(int argc, char *argv[]) {
     sleep(1);
   }
 
+#ifdef SYSTEMD
+  sd_notify(0, "STOPPING=1");
+  sd_notify(0, "STATUS=Shutdown");
+#endif
+
   /* If available, save the system time to the RTC */
   system_time_to_rtc();
 


### PR DESCRIPTION
When doing my foreground PR I forgot to change 'if (sd_notify(0, "STATUS=Startup") == 0)' back to 'sd_notify(0, "STATUS=Startup");'. As a result if a systemd is using systemd but sd_notify isn't working for whatever reason, the system will run in the foreground but not set the foreground flag. Currently this only logs to syslog which isn't incorrect, but any future changes will make this a worse bug.

I also added notification when the daemon shuts down. Not too important but it completes the trio of starting/running/shutting down.