### PR TITLE
Makefile: Move runtime installation to user-install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,28 +30,32 @@ help:
 install-init-0: # sysvinit
 	install -D -p initscript $(DESTDIR)/etc/init.d/lifepo4wered-daemon
 	sed -i "s:DAEMON_DIRECTORY:$(PREFIX)/sbin:" $(DESTDIR)/etc/init.d/lifepo4wered-daemon
-	update-rc.d lifepo4wered-daemon defaults
-	service lifepo4wered-daemon restart
 install-init-1: install-init-0 # systemd and sysvinit
 	install -D -p systemdscript $(DESTDIR)$(PREFIX)/lib/systemd/system/lifepo4wered-daemon.service
 	sed -i "s:DAEMON_DIRECTORY:$(PREFIX)/sbin:" $(DESTDIR)$(PREFIX)/lib/systemd/system/lifepo4wered-daemon.service
-	systemctl daemon-reload
-	systemctl enable lifepo4wered-daemon.service
-	systemctl restart lifepo4wered-daemon.service
 build/modules-load.conf:
 	echo "i2c-dev" > build/modules-load.conf
-enable-bus:
-        ifneq (, $(shell command -v raspi-config 2> /dev/null))
-	  raspi-config nonint do_i2c 0
-	  raspi-config nonint do_serial 0
-        endif
 install-files: all build/modules-load.conf
 	install -D -p build/liblifepo4wered.so $(DESTDIR)$(PREFIX)/lib/liblifepo4wered.so
 	install -D -p build/lifepo4wered-cli $(DESTDIR)$(PREFIX)/bin/lifepo4wered-cli
 	install -D -p build/lifepo4wered-daemon $(DESTDIR)$(PREFIX)/sbin/lifepo4wered-daemon
 	install -D -p build/modules-load.conf $(DESTDIR)/lib/modules-load.d/lifepo4wered.conf
 
-install: install-files install-init-$(USE_SYSTEMD) enable-bus;
+install: install-files install-init-$(USE_SYSTEMD)
+
+enable-bus:
+        ifneq (, $(shell command -v raspi-config 2> /dev/null))
+	  raspi-config nonint do_i2c 0
+	  raspi-config nonint do_serial 0
+        endif
+enable-init-0: # sysvinit
+	update-rc.d lifepo4wered-daemon defaults
+	service lifepo4wered-daemon restart
+enable-init-1: # systemd
+	systemctl daemon-reload
+	systemctl enable lifepo4wered-daemon.service
+	systemctl restart lifepo4wered-daemon.service
+user-install: install enable-bus enable-init-$(USE_SYSTEMD)
 
 clean:
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make all
 And install it:
 
 ```
-sudo ./INSTALL.sh
+sudo make user-install
 ```
 
 That's it!  You may need to restart for some configuration changes to take effect.


### PR DESCRIPTION
This re-organizes the makefile in to three distinct phases: build, install (copy files), and install (set up the system for the user). This decouples installing from packaging.