### PR TITLE
Use systemd-specific shutdown invocation

### DIFF
--- a/lifepo4wered-daemon.c
+++ b/lifepo4wered-daemon.c
@@ -73,6 +73,9 @@ void shut_down(void) {
     "\"$BALENA_SUPERVISOR_ADDRESS/v1/shutdown?" \
     "apikey=$BALENA_SUPERVISOR_API_KEY\"", NULL};
   execv("/bin/sh", params);
+#elif defined SYSTEMD
+  char *params[3] = {"systemctl", "poweroff", NULL};
+  execv("/bin/systemctl", params);
 #else
   char *params[3] = {"init", "0", NULL};
   execv("/sbin/init", params);


### PR DESCRIPTION
On OSes who don't bend themselves over backwards in an attempt at sysvinit-compatibility, `/sbin/init 0` does not shut down the system, but rather executes `systemd` itself in a non-PID1 context which it does not understand.

A reasonable alternative is `systemctl poweroff`.

Ideally `poweroff` could be used unilaterally, since both systemd and sysvinit OSes include a program by that name which accomplishes the named task when executed without argument; however, there is no agreement as to whether it should be in /usr/bin, /sbin, etc etc.

A reliable location of `systemctl` itself, is dictated by the usr-merge; see <https://serverfault.com/a/978288>.